### PR TITLE
Add more losses

### DIFF
--- a/smartpy/interfaces/dataset.py
+++ b/smartpy/interfaces/dataset.py
@@ -2,12 +2,12 @@ import theano
 
 
 class Dataset(object):
-    def __init__(self, inputs, targets, name="dataset"):
+    def __init__(self, inputs, targets=None, name="dataset"):
         self.name = name
         self.inputs = inputs
         self.targets = targets
-        self.symb_inputs = theano.tensor.matrix(name=self.name)
-        self.symb_targets = None if targets is None else theano.tensor.matrix(name=self.name+'_target')
+        self.symb_inputs = theano.tensor.matrix(name=self.name+'_inputs')
+        self.symb_targets = theano.tensor.matrix(name=self.name+'_targets')
 
     @property
     def inputs(self):

--- a/smartpy/interfaces/loss.py
+++ b/smartpy/interfaces/loss.py
@@ -8,12 +8,15 @@ class Loss(object):
         self.model = model
         self.dataset = dataset
         self.target = dataset.symb_targets
+        self.consider_constant = []  # Part of the computational graph to be consider as a constant.
 
     def get_graph_output(self):
         return self._loss_function(self.model.get_model_output(self.dataset.symb_inputs))
 
     def get_gradients(self):
-        gparams = T.grad(self.get_graph_output(), self.model.parameters)
+        gparams = T.grad(cost=self.get_graph_output(),
+                         wrt=self.model.parameters,
+                         consider_constant=self.consider_constant)
         gradients = dict(zip(self.model.parameters, gparams))
         return gradients, OrderedDict()
 

--- a/smartpy/interfaces/loss.py
+++ b/smartpy/interfaces/loss.py
@@ -18,22 +18,4 @@ class Loss(object):
         return gradients, OrderedDict()
 
     def _loss_function(self, model_output):
-        raise NotImplementedError("The loss function needs to be defined by subclassing the Loss class.")
-
-
-class NegativeLogLikelihood(Loss):
-    def _loss_function(self, model_output):
-        nll = -T.log(model_output)
-        indices = T.cast(self.target[:, 0], dtype="int32")  # Targets are floats.
-        selected_nll = nll[T.arange(self.target.shape[0]), indices]
-        return T.mean(selected_nll)
-
-
-class L2Distance(Loss):
-    def _loss_function(self, model_output):
-        return T.mean((model_output - self.target)**2)
-
-
-class L1Distance(Loss):
-    def _loss_function(self, model_output):
-        return T.mean(abs(model_output - self.target))
+        raise NotImplementedError("Subclass of 'Loss' must implement '_loss_function(model_output)'.")

--- a/smartpy/interfaces/loss.py
+++ b/smartpy/interfaces/loss.py
@@ -8,7 +8,7 @@ class Loss(object):
         self.model = model
         self.dataset = dataset
         self.target = dataset.symb_targets
-        self.consider_constant = []  # Part of the computational graph to be consider as a constant.
+        self.consider_constant = []  # Part of the computational graph to be considered as a constant.
 
     def get_graph_output(self):
         return self._loss_function(self.model.get_model_output(self.dataset.symb_inputs))

--- a/smartpy/losses/__init__.py
+++ b/smartpy/losses/__init__.py
@@ -1,0 +1,3 @@
+from .classification_losses import *
+from .distribution_losses import *
+from .reconstruction_losses import *

--- a/smartpy/losses/classification_losses.py
+++ b/smartpy/losses/classification_losses.py
@@ -1,0 +1,16 @@
+from smartpy.interfaces.loss import Loss
+
+import theano.tensor as T
+
+
+class NegativeLogLikelihood(Loss):
+    def _loss_function(self, model_output):
+        nll = -T.log(model_output)
+        indices = T.cast(self.target[:, 0], dtype="int32")  # Targets are floats.
+        selected_nll = nll[T.arange(self.target.shape[0]), indices]
+        return T.mean(selected_nll)
+
+
+class CategoricalCrossEntropy(Loss):
+    def _loss_function(self, model_output):
+        return T.mean(T.nnet.categorical_crossentropy(model_output, self.target))

--- a/smartpy/losses/distribution_losses.py
+++ b/smartpy/losses/distribution_losses.py
@@ -6,4 +6,3 @@ import theano.tensor as T
 class BinaryCrossEntropy(Loss):
     def _loss_function(self, model_output):
         return T.mean(T.nnet.binary_crossentropy(model_output, self.target))
-        #return T.mean(T.sum(T.nnet.softplus(-self.target.T * model_output.T + (1 - self.target.T) * model_output.T), axis=0))

--- a/smartpy/losses/distribution_losses.py
+++ b/smartpy/losses/distribution_losses.py
@@ -1,0 +1,9 @@
+from smartpy.interfaces.loss import Loss
+
+import theano.tensor as T
+
+
+class BinaryCrossEntropy(Loss):
+    def _loss_function(self, model_output):
+        return T.mean(T.nnet.binary_crossentropy(model_output, self.target))
+        #return T.mean(T.sum(T.nnet.softplus(-self.target.T * model_output.T + (1 - self.target.T) * model_output.T), axis=0))

--- a/smartpy/losses/reconstruction_losses.py
+++ b/smartpy/losses/reconstruction_losses.py
@@ -1,0 +1,13 @@
+from smartpy.interfaces.loss import Loss
+
+import theano.tensor as T
+
+
+class L2Distance(Loss):
+    def _loss_function(self, model_output):
+        return T.mean((model_output - self.target)**2)
+
+
+class L1Distance(Loss):
+    def _loss_function(self, model_output):
+        return T.mean(abs(model_output - self.target))


### PR DESCRIPTION
This PR cleaned `interface/loss.py` by moving `Loss` subclasses to a seperate files/folder.

A new folder has been created at the root of the project named: `losses`. Inside, there are three files: `distribution_losses.py`, `classification_losses.py` and `reconstruction_losses.py`.
