### PR TITLE
Install automatically *all* submodules contained in the library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,15 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+
+from setuptools import setup, find_packages
 
 setup(
     name='smartlearner',
     version='0.0.1',
     author='Marc-Alexandre Côté, Adam Salvail, Mathieu Germain',
     author_email='smart-udes-dev@googlegroups.com',
-    packages=['smartlearner'],
     url='https://github.com/SMART-Lab/smartpy',
+    packages=find_packages(),
     license='LICENSE',
     description='A machine learning library built with researchers in mind.',
     long_description=open('README.md').read(),

--- a/smartlearner/__init__.py
+++ b/smartlearner/__init__.py
@@ -1,5 +1,5 @@
-from smartlearner.interfaces.model import Model
-from smartlearner.interfaces.dataset import Dataset
-from smartlearner.trainer import Trainer
+from .interfaces.model import Model
+from .interfaces.dataset import Dataset
+from .trainer import Trainer
 
-from smartlearner.tasks import tasks
+from .tasks import tasks


### PR DESCRIPTION
It seems we were only installing the root directory `smartlearner` without any submodules (e.g. optimizers, interfaces, ...).
