### PR TITLE
Use symbolic variables coming from the dataset

### DIFF
--- a/smartlearner/tasks/views.py
+++ b/smartlearner/tasks/views.py
@@ -47,8 +47,8 @@ class ClassificationError(View):
         batch_size = 1024  # Internal buffer
         self.nb_batches = int(np.ceil(len(dataset) / batch_size))
 
-        input = T.matrix('input')
-        target = T.matrix('target')
+        input = dataset.symb_inputs
+        target = dataset.symb_targets
         classification_errors = T.neq(predict_fct(input), target)
 
         no_batch = T.iscalar('no_batch')


### PR DESCRIPTION
The symbolic variables needed for the function `model.use`  were created directly in the task independently from the datatype of the dataset. For instance, working with sequences, requiring `T.tensor3` variables, would fail since `T.matrix` variables were used instead. Now, the task used the right type of variables by using the ones from the dataset instead.
