### PR TITLE
In EarlyStopping restore model in method finished

### DIFF
--- a/smartlearner/stopping_criteria.py
+++ b/smartlearner/stopping_criteria.py
@@ -77,10 +77,10 @@ class EarlyStopping(Task):
                 self.callback(self, status)
 
         if status.current_epoch - self.best_epoch >= self.lookahead:
-            self._restore_model(status)
             raise TrainingExit(status)
 
     def finished(self, status):
+        self._restore_model(status)
         print("Early Stopping : training finished with best cost {:.3f} at epoch {}.".format(self.best_cost, self.best_epoch))
 
     def _stash_model(self, status):


### PR DESCRIPTION
Presently, if your script has other stopping criteria (e.g. `MaxEpoch`) in addition to `EarlyStopping`, the model might not be restore. Actually, it will happen whenever `EarlyStopping` is not the function that raises `TrainingExit`. Moving the restoration of the model in the `finished` method will solve this problem.
