### PR TITLE
Add option telling Theano do not transfer a dataset to the GPU

### DIFF
--- a/smartlearner/interfaces/dataset.py
+++ b/smartlearner/interfaces/dataset.py
@@ -20,7 +20,7 @@ class Dataset(object):
     `symb_inputs` and `symb_targets` have test value already tagged to them. Use
     THEANO_FLAGS="compute_test_value=warn" to use them.
     """
-    def __init__(self, inputs, targets=None, name="dataset"):
+    def __init__(self, inputs, targets=None, name="dataset", keep_on_cpu=False):
         """
         Parameters
         ----------
@@ -32,6 +32,7 @@ class Dataset(object):
             The name of the dataset is used to name Theano variables. Default: 'dataset'.
         """
         self.name = name
+        self.keep_on_cpu = keep_on_cpu
         self.inputs = inputs
         self.targets = targets
         self.symb_inputs = T.TensorVariable(type=T.TensorType("floatX", [False]*self.inputs.ndim),
@@ -50,7 +51,7 @@ class Dataset(object):
 
     @inputs.setter
     def inputs(self, value):
-        self._inputs_shared = sharedX(value, name=self.name+"_inputs")
+        self._inputs_shared = sharedX(value, name=self.name+"_inputs", keep_on_cpu=self.keep_on_cpu)
 
     @property
     def targets(self):
@@ -59,7 +60,7 @@ class Dataset(object):
     @targets.setter
     def targets(self, value):
         if value is not None:
-            self._targets_shared = sharedX(np.array(value), name=self.name+"_targets")
+            self._targets_shared = sharedX(np.array(value), name=self.name+"_targets", keep_on_cpu=self.keep_on_cpu)
         else:
             self._targets_shared = None
 

--- a/smartlearner/utils.py
+++ b/smartlearner/utils.py
@@ -1,9 +1,15 @@
 import json
 import theano
+import theano.tensor as T
 
 
-def sharedX(value, name=None, borrow=True):
+def sharedX(value, name=None, borrow=True, keep_on_cpu=False):
     """ Transform value into a shared variable of type floatX """
+    if keep_on_cpu:
+        return T._shared(theano._asarray(value, dtype=theano.config.floatX),
+                         name=name,
+                         borrow=borrow)
+
     return theano.shared(theano._asarray(value, dtype=theano.config.floatX),
                          name=name,
                          borrow=borrow)


### PR DESCRIPTION
Often you have too much data and it can all fit on the GPU's RAM. If it is your case, you can now provide `keep_on_cpu=True` as argument to the Dataset constructor. Theano will transfer data as it needs (one batch at the time) to the GPU. See this for more infos https://groups.google.com/forum/#!topic/theano-users/ZagTpkB4hGg
