### PR TITLE
`Loss` subclasses should compute the loss of every example in the batch

### DIFF
--- a/smartlearner/batch_schedulers.py
+++ b/smartlearner/batch_schedulers.py
@@ -50,4 +50,4 @@ class MiniBatchScheduler(BatchScheduler):
 
 class FullBatchScheduler(MiniBatchScheduler):
     def __init__(self, dataset):
-        super(FullBatchScheduler, self).__init__(dataset, batch_size=len(self.dataset))
+        super(FullBatchScheduler, self).__init__(dataset, batch_size=len(dataset))

--- a/smartlearner/interfaces/loss.py
+++ b/smartlearner/interfaces/loss.py
@@ -17,6 +17,7 @@ class Loss(object):
 
         # Build the graph for the loss.
         model_output = self.model.get_output(self.dataset.symb_inputs)
+        self._batch_losses = self._compute_batch_losses(model_output)
         self._loss = self._compute_loss(model_output)
 
     @abstractmethod
@@ -24,8 +25,11 @@ class Loss(object):
         raise NotImplementedError("Subclass of 'Loss' must implement '_get_updates()'.")
 
     @abstractmethod
+    def _compute_batch_losses(self, model_output):
+        raise NotImplementedError("Subclass of 'Loss' must implement '_compute_batch_losses(model_output)'.")
+
     def _compute_loss(self, model_output):
-        raise NotImplementedError("Subclass of 'Loss' must implement '_compute_loss(model_output)'.")
+        return T.mean(self._compute_batch_losses(model_output))
 
     @property
     def gradients(self):

--- a/smartlearner/interfaces/loss.py
+++ b/smartlearner/interfaces/loss.py
@@ -14,22 +14,46 @@ class Loss(object):
         self.consider_constant = []  # Part of the computational graph to be considered as a constant.
         self._tasks = []
         self._gradients = None
-
-        # Build the graph for the loss.
-        model_output = self.model.get_output(self.dataset.symb_inputs)
-        self._batch_losses = self._compute_batch_losses(model_output)
-        self._loss = self._compute_loss(model_output)
+        self._loss = None
+        self._losses = None
 
     @abstractmethod
     def _get_updates(self):
         raise NotImplementedError("Subclass of 'Loss' must implement '_get_updates()'.")
 
-    @abstractmethod
-    def _compute_batch_losses(self, model_output):
-        raise NotImplementedError("Subclass of 'Loss' must implement '_compute_batch_losses(model_output)'.")
+    def _compute_losses(self, model_output):
+        class_name = self.__class__.__name__
+        raise NotImplementedError("{0} does not implement '_compute_losses(model_output)'.".format(class_name))
 
     def _compute_loss(self, model_output):
-        return T.mean(self._compute_batch_losses(model_output))
+        """ Computes the loss for the whole batch.
+
+        Notes:
+        ------
+        Unless overriden, the default behavior is to return the mean of all individual losses.
+        """
+        try:
+            return T.mean(self.losses)
+        except NotImplementedError:
+            raise NotImplementedError("Subclass of 'Loss' must either implement '_compute_loss(model_output)' or '_compute_losses(model_output)'.")
+
+    @property
+    def losses(self):
+        """ Gets individual losses (one for each batch example). """
+        if self._losses is None:
+            model_output = self.model.get_output(self.dataset.symb_inputs)
+            self._losses = self._compute_losses(model_output)
+
+        return self._losses
+
+    @property
+    def loss(self):
+        """ Gets loss for the whole batch. """
+        if self._loss is None:
+            model_output = self.model.get_output(self.dataset.symb_inputs)
+            self._loss = self._compute_loss(model_output)
+
+        return self._loss
 
     @property
     def gradients(self):
@@ -50,7 +74,7 @@ class Loss(object):
         return updates
 
     def _get_gradients(self):
-        gparams = T.grad(cost=self._loss,
+        gparams = T.grad(cost=self.loss,
                          wrt=self.model.parameters,
                          consider_constant=self.consider_constant)
         self._gradients = dict(zip(self.model.parameters, gparams))

--- a/smartlearner/losses/classification_losses.py
+++ b/smartlearner/losses/classification_losses.py
@@ -7,7 +7,7 @@ class NegativeLogLikelihood(Loss):
     def _get_updates(self):
         return {}  # There is no updates for NegativeLogLikelihood.
 
-    def _compute_batch_losses(self, model_output):
+    def _compute_losses(self, model_output):
         nll = -T.log(model_output)
         indices = T.cast(self.dataset.symb_targets[:, 0], dtype="int32")  # Targets are floats.
         selected_nll = nll[T.arange(self.dataset.symb_targets.shape[0]), indices]
@@ -18,7 +18,7 @@ class CategoricalCrossEntropy(Loss):
     def _get_updates(self):
         return {}  # There is no updates for CategoricalCrossEntropy.
 
-    def _compute_batch_losses(self, model_output):
+    def _compute_losses(self, model_output):
         return T.nnet.categorical_crossentropy(model_output, self.dataset.symb_targets)
 
 
@@ -31,6 +31,6 @@ class ClassificationError(Loss):
     def _get_updates(self):
         return {}  # There is no updates for ClassificationError.
 
-    def _compute_batch_losses(self, model_output):
+    def _compute_losses(self, model_output):
         predictions = T.argmax(model_output, axis=1, keepdims=True)
         return T.neq(predictions, self.dataset.symb_targets)

--- a/smartlearner/losses/classification_losses.py
+++ b/smartlearner/losses/classification_losses.py
@@ -7,16 +7,30 @@ class NegativeLogLikelihood(Loss):
     def _get_updates(self):
         return {}  # There is no updates for NegativeLogLikelihood.
 
-    def _compute_loss(self, model_output):
+    def _compute_batch_losses(self, model_output):
         nll = -T.log(model_output)
         indices = T.cast(self.dataset.symb_targets[:, 0], dtype="int32")  # Targets are floats.
         selected_nll = nll[T.arange(self.dataset.symb_targets.shape[0]), indices]
-        return T.mean(selected_nll)
+        return selected_nll
 
 
 class CategoricalCrossEntropy(Loss):
     def _get_updates(self):
         return {}  # There is no updates for CategoricalCrossEntropy.
 
-    def _compute_loss(self, model_output):
-        return T.mean(T.nnet.categorical_crossentropy(model_output, self.dataset.symb_targets))
+    def _compute_batch_losses(self, model_output):
+        return T.nnet.categorical_crossentropy(model_output, self.dataset.symb_targets)
+
+
+class ClassificationError(Loss):
+    """
+    Notes:
+    ------
+    Each target should be the ID of the class.
+    """
+    def _get_updates(self):
+        return {}  # There is no updates for ClassificationError.
+
+    def _compute_batch_losses(self, model_output):
+        predictions = T.argmax(model_output, axis=1, keepdims=True)
+        return T.neq(predictions, self.dataset.symb_targets)

--- a/smartlearner/losses/distribution_losses.py
+++ b/smartlearner/losses/distribution_losses.py
@@ -7,5 +7,5 @@ class BinaryCrossEntropy(Loss):
     def _get_updates(self):
         return {}  # There is no updates for BinaryCrossEntropy.
 
-    def _compute_loss(self, model_output):
-        return T.mean(T.nnet.binary_crossentropy(model_output, self.dataset.symb_targets))
+    def _compute_batch_losses(self, model_output):
+        return T.nnet.binary_crossentropy(model_output, self.dataset.symb_targets)

--- a/smartlearner/losses/distribution_losses.py
+++ b/smartlearner/losses/distribution_losses.py
@@ -7,5 +7,5 @@ class BinaryCrossEntropy(Loss):
     def _get_updates(self):
         return {}  # There is no updates for BinaryCrossEntropy.
 
-    def _compute_batch_losses(self, model_output):
+    def _compute_losses(self, model_output):
         return T.nnet.binary_crossentropy(model_output, self.dataset.symb_targets)

--- a/smartlearner/losses/reconstruction_losses.py
+++ b/smartlearner/losses/reconstruction_losses.py
@@ -1,4 +1,4 @@
-import thenao.tensor as T
+import theano.tensor as T
 
 from ..interfaces import Loss
 

--- a/smartlearner/losses/reconstruction_losses.py
+++ b/smartlearner/losses/reconstruction_losses.py
@@ -7,7 +7,7 @@ class L2Distance(Loss):
     def _get_updates(self):
         return {}  # There is no updates for L2Distance.
 
-    def _compute_batch_losses(self, model_output):
+    def _compute_losses(self, model_output):
         return T.mean((model_output - self.dataset.symb_targets)**2, axis=1)
 
 
@@ -15,5 +15,5 @@ class L1Distance(Loss):
     def _get_updates(self):
         return {}  # There is no updates for L1Distance.
 
-    def _compute_batch_losses(self, model_output):
+    def _compute_losses(self, model_output):
         return T.mean(abs(model_output - self.dataset.symb_targets), axis=1)

--- a/smartlearner/losses/reconstruction_losses.py
+++ b/smartlearner/losses/reconstruction_losses.py
@@ -1,4 +1,4 @@
-import theano.tensor as T
+import thenao.tensor as T
 
 from ..interfaces import Loss
 
@@ -7,13 +7,13 @@ class L2Distance(Loss):
     def _get_updates(self):
         return {}  # There is no updates for L2Distance.
 
-    def _compute_loss(self, model_output):
-        return T.mean((model_output - self.dataset.symb_targets)**2)
+    def _compute_batch_losses(self, model_output):
+        return T.mean((model_output - self.dataset.symb_targets)**2, axis=1)
 
 
 class L1Distance(Loss):
     def _get_updates(self):
         return {}  # There is no updates for L1Distance.
 
-    def _compute_loss(self, model_output):
-        return T.mean(abs(model_output - self.dataset.symb_targets))
+    def _compute_batch_losses(self, model_output):
+        return T.mean(abs(model_output - self.dataset.symb_targets), axis=1)

--- a/smartlearner/testing.py
+++ b/smartlearner/testing.py
@@ -39,7 +39,7 @@ class DummyLoss(Loss):
     def __init__(self):
         super(DummyLoss, self).__init__(DummyModel(), DummyDataset())
 
-    def _compute_loss(self, model_output):
+    def _compute_batch_losses(self, model_output):
         return model_output
 
     def _get_updates(self):

--- a/smartlearner/views.py
+++ b/smartlearner/views.py
@@ -31,7 +31,7 @@ class LossView(View):
         graph_updates.update(batch_scheduler.updates)
 
         self.compute_loss = theano.function([],
-                                            loss._batch_losses,
+                                            loss.losses,
                                             updates=graph_updates,
                                             givens=batch_scheduler.givens,
                                             name="compute_loss")


### PR DESCRIPTION
Right now, `Loss` subclasses have to override `_compute_loss` which return the loss of the batch. I think it will be more useful if it was returning the loss of every example in the batch.

This PR changes every loss classes so they return an array of scalars instead of only one scalar. It also changes the name of the method to override: `_compute_batch_losses`.

To show how why this modification is useful, I added an new view `LossView` that provides an easy way of computing any loss on a particular dataset using any batch scheduler. Basically, it allows replacing both `views.RegressionError` and `views.ClassificationError` views respectively by

``` python
LossView(loss=losses.L2Distance(model, validset),
         batch_scheduler=FullBatchScheduler(validset))
LossView(loss=losses.ClassificationError(model, validset), 
         batch_scheduler=FullBatchScheduler(validset))
```
