### PR TITLE
Move the graph compilation to its own private method.

### DIFF
--- a/smartlearner/trainer.py
+++ b/smartlearner/trainer.py
@@ -21,6 +21,8 @@ class Trainer(object):
         self._tasks.extend(self._optimizer.tasks)
         self._tasks.extend(self._batch_scheduler.tasks)
 
+        self._learn = None
+
     def train(self):
         self._pre_learning()
         self._learning()
@@ -38,10 +40,11 @@ class Trainer(object):
                                       updates=self._graph_updates,
                                       givens=self._batch_scheduler.givens,
                                       name="learn")
+        #theano.printing.pydotprint(self._learn, '{0}_learn_{1}'.format(self._optimizer.loss.model.__class__.__name__, theano.config.device), with_ids=True)
 
     def _pre_learning(self):
-        self._build_theano_graph()
-        #theano.printing.pydotprint(learn, '{0}_learn_{1}'.format(self.optimizer.model.__class__.__name__, theano.config.device), with_ids=True)
+        if self._learn is None:
+            self._build_theano_graph()
 
         # Only initialize tasks if not resuming
         if self.status.current_update == 0:

--- a/smartlearner/trainer.py
+++ b/smartlearner/trainer.py
@@ -31,7 +31,7 @@ class Trainer(object):
     def append_task(self, task):
         self._tasks.append(task)
 
-    def _build_theano_graph(self):
+    def build_theano_graph(self):
         # Get updates from tasks.
         for task in self._tasks:
             self._graph_updates.update(task.updates)
@@ -44,7 +44,7 @@ class Trainer(object):
 
     def _pre_learning(self):
         if self._learn is None:
-            self._build_theano_graph()
+            self.build_theano_graph()
 
         # Only initialize tasks if not resuming
         if self.status.current_update == 0:


### PR DESCRIPTION
By moving the code responsible for the graph compilation, we allow timing that process. For instance:

``` python
with Timer("Graph compiling"):
    trainer._build_theano_graph()

with Timer("Training"):
    trainer.run()
```

Note that graph compilation will be automatically done, if needed, when calling `trainer.run()`.
