### PR TITLE
Two changes that make life easier.

### DIFF
--- a/smartlearner/stopping_criteria.py
+++ b/smartlearner/stopping_criteria.py
@@ -60,12 +60,6 @@ class EarlyStopping(Task):
         self._stash_model(status)
 
     def post_epoch(self, status):
-        if status.current_epoch <= self.min_nb_epochs:
-            # The last skipped epoch should be considered as the best.
-            self.best_epoch = status.current_epoch
-            self._stash_model(status)
-            return
-
         cost = float(self.cost.view(status))
         if cost + self.eps < self.best_cost:
             self.best_epoch = status.current_epoch
@@ -76,7 +70,7 @@ class EarlyStopping(Task):
             if self.callback is not None:
                 self.callback(self, status)
 
-        if status.current_epoch - self.best_epoch >= self.lookahead:
+        if status.current_epoch - self.best_epoch >= self.lookahead and status.current_epoch >= self.min_nb_epochs:
             raise TrainingExit(status)
 
     def finished(self, status):

--- a/smartlearner/tasks.py
+++ b/smartlearner/tasks.py
@@ -38,11 +38,13 @@ class Breakpoint(RecurrentTask):
 
 
 class Print(RecurrentTask):
-    def __init__(self, msg, *views, **recurrent_options):
+    def __init__(self, msg, *views, print_epoch=True, print_update=False, **recurrent_options):
         # TODO: docstring should include **recurrent_options.
         super(Print, self).__init__(**recurrent_options)
         self.msg = msg
         self.views = views
+        self._p_epoch = print_epoch
+        self._p_update = print_update
 
         # Add updates of the views.
         for view in self.views:
@@ -50,7 +52,11 @@ class Print(RecurrentTask):
 
     def execute(self, status):
         values = [view.view(status) for view in self.views]
-        print("{}:{}  ".format(status.current_epoch, status.current_update_in_epoch), self.msg.format(*values))
+        if self._p_epoch:
+            print(status.current_epoch, end=':')
+        if self._p_update:
+            print(status.current_update_in_epoch, end='  ')
+        print(self.msg.format(*values))
 
 
 class SaveToFile(Task):

--- a/smartlearner/tasks.py
+++ b/smartlearner/tasks.py
@@ -50,7 +50,7 @@ class Print(RecurrentTask):
 
     def execute(self, status):
         values = [view.view(status) for view in self.views]
-        print(self.msg.format(*values))
+        print("{}:{}  ".format(status.current_epoch, status.current_update_in_epoch), self.msg.format(*values))
 
 
 class SaveToFile(Task):

--- a/tests/tasks/test_stopping_criteria.py
+++ b/tests/tasks/test_stopping_criteria.py
@@ -103,7 +103,7 @@ def test_early_stopping():
 
     # Test `min_nb_epochs`
     lookahead = 9
-    min_nb_epochs = 5
+    min_nb_epochs = 15
     costs = range(20)
     increasing_cost = DummyCost(0, costs)
     early_stopping = stopping_criteria.EarlyStopping(increasing_cost, lookahead, min_nb_epochs=min_nb_epochs)
@@ -113,7 +113,7 @@ def test_early_stopping():
     trainer.append_task(stopping_criteria.MaxEpochStopping(MAX_EPOCH))  # To be safe
     trainer.train()
 
-    assert_equal(trainer.status.current_epoch, lookahead+min_nb_epochs)
+    assert_equal(trainer.status.current_epoch, min_nb_epochs)
 
     # Test that at the end the model is the best one.
     # `lookahead` decreasing costs followed by `lookahead+1` constant identical costs.


### PR DESCRIPTION
1. `Print` task now also output the epoch and update where it has been used.
2. `nb_min_epochs` now works only as an initial minimum look ahead. This way, if the model was trained really fast, it won't try to use a worse model.
