### PR TITLE
Use a fixed path for miniconda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - cd download
   - wget -c http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
-  - ./miniconda.sh -b
+  - ./miniconda.sh -b -p $HOME/miniconda
   - cd ..
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda


### PR DESCRIPTION
Continuum decided to change the home path to `miniconda2`.
