### PR TITLE
Made sure BinaryCrossEntropy return the losses of the batch.

### DIFF
--- a/smartlearner/losses/distribution_losses.py
+++ b/smartlearner/losses/distribution_losses.py
@@ -8,4 +8,4 @@ class BinaryCrossEntropy(Loss):
         return {}  # There is no updates for BinaryCrossEntropy.
 
     def _compute_losses(self, model_output):
-        return T.nnet.binary_crossentropy(model_output, self.dataset.symb_targets)
+        return T.sum(T.nnet.binary_crossentropy(model_output, self.dataset.symb_targets), axis=1)

--- a/smartlearner/tasks.py
+++ b/smartlearner/tasks.py
@@ -1,7 +1,7 @@
 from time import time
 
 from .interfaces import Task, RecurrentTask, View
-from .views import MonitorVariable
+from .views import MonitorVariable, ItemGetter
 
 
 class PrintEpochDuration(RecurrentTask):
@@ -161,3 +161,6 @@ class AveragePerEpoch(View, Accumulator):
 
     def pre_epoch(self, status):
         self.clear()
+
+    def __getitem__(self, idx):
+        return ItemGetter(self, attribute=idx)


### PR DESCRIPTION
The `BinaryCrossEntropy` and `ClassificationError` were returning the loss of the whole batch instead of the loss of each individual example (as done with other `Loss` functions, e.g. [L2Distance](https://github.com/SMART-Lab/smartlearner/blob/master/smartlearner/losses/reconstruction_losses.py#L11) and [L1Distance](https://github.com/SMART-Lab/smartlearner/blob/master/smartlearner/losses/reconstruction_losses.py#L19)).

This PR fixes that and brings some unit tests.
