### PR TITLE
Make AveragePerEpoch indexable

### DIFF
--- a/smartlearner/tasks.py
+++ b/smartlearner/tasks.py
@@ -1,7 +1,7 @@
 from time import time
 
 from .interfaces import Task, RecurrentTask, View
-from .views import MonitorVariable
+from .views import MonitorVariable, ItemGetter
 
 
 class PrintEpochDuration(RecurrentTask):
@@ -161,3 +161,6 @@ class AveragePerEpoch(View, Accumulator):
 
     def pre_epoch(self, status):
         self.clear()
+
+    def __getitem__(self, idx):
+        return ItemGetter(self, attribute=idx)


### PR DESCRIPTION
A really small PR to make the `AveragePerEpoch` tasks indexable. It is useful when using with the `Logger` task.
