### PR TITLE
Temporary bugfix; LossView fetches wrong updates

### DIFF
--- a/smartlearner/views.py
+++ b/smartlearner/views.py
@@ -25,13 +25,15 @@ class LossView(View):
 
         self.batch_scheduler = batch_scheduler
 
+        losses = loss.losses
+
         # Gather updates from the optimizer and the batch scheduler.
         graph_updates = OrderedDict()
         graph_updates.update(loss.updates)
         graph_updates.update(batch_scheduler.updates)
 
         self.compute_loss = theano.function([],
-                                            loss.losses,
+                                            losses,
                                             updates=graph_updates,
                                             givens=batch_scheduler.givens,
                                             name="compute_loss")


### PR DESCRIPTION
`Loss.losses` triggers an important call to `self.model.get_output(self.dataset.symb_inputs)`, which updates the model's `self.graph_updates` dictionary using the given dataset. If a new LossView is created using a different dataset, `loss.updates` will fetch the updates from the old `symb_inputs`, which can be a cause for errors.
