### PR TITLE
Now saving the logger task. Also adds CallbackView

### DIFF
--- a/smartlearner/interfaces/view.py
+++ b/smartlearner/interfaces/view.py
@@ -11,8 +11,12 @@ class View(object):
         self.last_update = -1
         self.last_epoch = -1
 
-    def view(self, status):
-        if self.last_update != status.current_update or self.last_epoch != status.current_epoch:
+    def view(self, status=None):
+        if status is None:
+            # Force recomputation of the value.
+            self.value = self.update(status)
+
+        elif self.last_update != status.current_update or self.last_epoch != status.current_epoch:
             self.value = self.update(status)
             self.last_update = status.current_update
             self.last_epoch = status.current_epoch
@@ -20,7 +24,7 @@ class View(object):
         return self.value
 
     @abstractmethod
-    def update(self, status):
+    def update(self, status=None):
         raise NotImplementedError("Subclass of 'View' must implement 'update(status)'.")
 
     def __str__(self):

--- a/smartlearner/tasks.py
+++ b/smartlearner/tasks.py
@@ -138,6 +138,15 @@ class Logger(RecurrentTask):
     def _get_variable_history(self, index):
         return self._history[index]
 
+    def save(self, path):
+        state = {"version": 1,
+                 "history": self._history}
+        utils.save_dict_to_json_file(pjoin(path, "logger.json"), state)
+
+    def load(self, path):
+        state = utils.load_dict_from_json_file(pjoin(path, "logger.json"))
+        self._history = state["history"]
+
 
 class Accumulator(Logger):
     def _log(self, values_to_log):

--- a/smartlearner/tasks.py
+++ b/smartlearner/tasks.py
@@ -141,10 +141,12 @@ class Logger(RecurrentTask):
     def save(self, path):
         state = {"version": 1,
                  "history": self._history}
-        utils.save_dict_to_json_file(pjoin(path, "logger.json"), state)
+        filename = type(self).__name__ + ".json"
+        utils.save_dict_to_json_file(pjoin(path, filename), state)
 
     def load(self, path):
-        state = utils.load_dict_from_json_file(pjoin(path, "logger.json"))
+        filename = type(self).__name__ + ".json"
+        state = utils.load_dict_from_json_file(pjoin(path, filename))
         self._history = state["history"]
 
 

--- a/smartlearner/trainer.py
+++ b/smartlearner/trainer.py
@@ -52,8 +52,10 @@ class Trainer(object):
         self._batch_scheduler.save(savedir)
 
         tasks_dir = utils.create_folder(pjoin(savedir, 'tasks'))
-        for task in self._tasks:
-            task.save(tasks_dir)
+        for i, task in enumerate(self._tasks):
+            # Save each task in its own folder.
+            task_dir = utils.create_folder(pjoin(tasks_dir, 'task_{}'.format(i)))
+            task.save(task_dir)
 
     def load(self, path):
         loaddir = pjoin(path, "training")
@@ -62,8 +64,9 @@ class Trainer(object):
         self._batch_scheduler.load(loaddir)
 
         tasks_dir = pjoin(loaddir, 'tasks')
-        for task in self._tasks:
-            task.load(tasks_dir)
+        for i, task in enumerate(self._tasks):
+            task_dir = pjoin(tasks_dir, 'task_{}'.format(i))
+            task.load(task_dir)
 
     def _pre_learning(self):
         if self._learn is None:

--- a/smartlearner/views.py
+++ b/smartlearner/views.py
@@ -10,13 +10,16 @@ from .interfaces import View
 class ItemGetter(View):
     def __init__(self, view, attribute):
         """ Retrieves `attribute` from a `view` which return an indexable object. """
-        super(ItemGetter, self).__init__()
+        super().__init__()
         self.view_obj = view
         self.attribute = attribute
 
     def update(self, status):
         infos = self.view_obj.view(status)
         return infos[self.attribute]
+
+    def __getitem__(self, idx):
+        return ItemGetter(self, attribute=idx)
 
 
 class LossView(View):
@@ -73,6 +76,15 @@ class MonitorVariable(View):
         var_shared = theano.shared(np.array(0, dtype=var.dtype, ndmin=var.ndim), name=name)
         self.updates[var_shared] = var
         return var_shared
+
+
+class CallbackView(View):
+    def __init__(self, callback):
+        super().__init__()
+        self.callback = callback
+
+    def update(self, status):
+        return self.callback(self, status)
 
 
 class ClassificationError(View):

--- a/tests/direction_modifiers/test_constant_learning_rate.py
+++ b/tests/direction_modifiers/test_constant_learning_rate.py
@@ -4,7 +4,7 @@ import theano.tensor as T
 import unittest
 import tempfile
 
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from smartlearner import views, stopping_criteria, Trainer, tasks
 from smartlearner.direction_modifiers import ConstantLearningRate
@@ -61,7 +61,8 @@ class TestConstantLearningRate(unittest.TestCase):
     def test_behaviour(self):
         learning_rate_per_update = np.array(self.logger.get_variable_history(0))[:, :, 0].flatten()
         expected_learning_rate_per_update = [self.lr for _ in range(self.max_epoch)]
-        assert_array_equal(learning_rate_per_update, expected_learning_rate_per_update)
+        # Using `assert_array_*almost*_equal` because of float32. However, this is not needed in float64.
+        assert_array_almost_equal(learning_rate_per_update, expected_learning_rate_per_update)
 
     def test_save_load(self):
         # Save training and resume it.
@@ -94,9 +95,7 @@ class TestConstantLearningRate(unittest.TestCase):
             trainer2.load(experiment_dir)
             trainer2.train()
 
-        # Check that concatenating `logger1` with `logger2` is the same as `self.logger`.
-        learning_rate_per_update_part1 = np.array(logger1.get_variable_history(0))[:, :, 0].flatten()
+        # Check that `logger2` is the same as `self.logger` for all logged variables.
         learning_rate_per_update_part2 = np.array(logger2.get_variable_history(0))[:, :, 0].flatten()
         expected_learning_rate_per_update = np.array(self.logger.get_variable_history(0))[:, :, 0].flatten()
-        assert_array_equal(np.r_[learning_rate_per_update_part1, learning_rate_per_update_part2],
-                           expected_learning_rate_per_update)
+        assert_array_equal(learning_rate_per_update_part2, expected_learning_rate_per_update)

--- a/tests/direction_modifiers/test_decreasing_learning_rate.py
+++ b/tests/direction_modifiers/test_decreasing_learning_rate.py
@@ -95,9 +95,7 @@ class TestDecreasingLearningRate(unittest.TestCase):
             trainer2.load(experiment_dir)
             trainer2.train()
 
-        # Check that concatenating `logger1` with `logger2` is the same as `self.logger`.
-        learning_rate_per_update_part1 = np.array(logger1.get_variable_history(0))[:, :, 0].flatten()
-        learning_rate_per_update_part2 = np.array(logger2.get_variable_history(0))[:, :, 0].flatten()
+        # Check that `logger2` is the same as `self.logger`.
+        learning_rate_per_update2 = np.array(logger2.get_variable_history(0))[:, :, 0].flatten()
         expected_learning_rate_per_update = np.array(self.logger.get_variable_history(0))[:, :, 0].flatten()
-        assert_array_equal(np.r_[learning_rate_per_update_part1, learning_rate_per_update_part2],
-                           expected_learning_rate_per_update)
+        assert_array_equal(learning_rate_per_update2, expected_learning_rate_per_update)

--- a/tests/direction_modifiers/test_direction_clipping.py
+++ b/tests/direction_modifiers/test_direction_clipping.py
@@ -3,7 +3,7 @@ import theano
 import theano.tensor as T
 import unittest
 
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 from nose.tools import assert_true
 
 from smartlearner import views, stopping_criteria, Trainer, tasks
@@ -77,5 +77,5 @@ class TestDirectionClipping(unittest.TestCase):
 
             gradients = np.array(logger.get_variable_history(2)).squeeze()
             norms = np.array(logger.get_variable_history(3)).squeeze()[:, None]
-            assert_array_equal(gradients_clipped,
-                               gradients*threshold/np.maximum(threshold, norms))
+            assert_array_almost_equal(gradients_clipped,
+                                      gradients*threshold/np.maximum(threshold, norms))

--- a/tests/direction_modifiers/test_gradient_noise.py
+++ b/tests/direction_modifiers/test_gradient_noise.py
@@ -117,23 +117,8 @@ class TestGradientNoise(unittest.TestCase):
             trainer2.load(experiment_dir)
             trainer2.train()
 
-        # Check that concatenating `logger1` with `logger2` is the same as `self.logger`.
-        learning_rate_per_update_part1 = np.array(logger1.get_variable_history(0)).flatten()
-        learning_rate_per_update_part2 = np.array(logger2.get_variable_history(0)).flatten()
-        expected_learning_rate_per_update = np.array(self.logger.get_variable_history(0)).flatten()
-        assert_array_equal(np.r_[learning_rate_per_update_part1, learning_rate_per_update_part2],
-                           expected_learning_rate_per_update)
-
-        # Check that concatenating `logger1` with `logger2` is the same as `self.logger`.
-        learning_rate_per_update_part1 = np.array(logger1.get_variable_history(1)).flatten()
-        learning_rate_per_update_part2 = np.array(logger2.get_variable_history(1)).flatten()
-        expected_learning_rate_per_update = np.array(self.logger.get_variable_history(1)).flatten()
-        assert_array_equal(np.r_[learning_rate_per_update_part1, learning_rate_per_update_part2],
-                           expected_learning_rate_per_update)
-
-        # Check that concatenating `logger1` with `logger2` is the same as `self.logger`.
-        learning_rate_per_update_part1 = np.array(logger1.get_variable_history(2)).flatten()
-        learning_rate_per_update_part2 = np.array(logger2.get_variable_history(2)).flatten()
-        expected_learning_rate_per_update = np.array(self.logger.get_variable_history(2)).flatten()
-        assert_array_almost_equal(np.r_[learning_rate_per_update_part1, learning_rate_per_update_part2],
-                                  expected_learning_rate_per_update)
+        for i in range(3):
+            # Check that `logger2` is the same as `self.logger` for all logged variables.
+            learning_rate_per_update2 = np.array(logger2.get_variable_history(i)).flatten()
+            expected_learning_rate_per_update = np.array(self.logger.get_variable_history(i)).flatten()
+            assert_array_equal(learning_rate_per_update2, expected_learning_rate_per_update)

--- a/tests/test_smartlearner.py
+++ b/tests/test_smartlearner.py
@@ -274,17 +274,17 @@ def test_resume_experiment():
         for param1, param2 in zip(trainer1._optimizer.loss.model.parameters,
                                   trainer2b._optimizer.loss.model.parameters):
 
-            # I tested it, they are exactly equal when using float64.
+            # Using `assert_array_*almost*_equal` because of float32. However, this is not needed in float64.
             assert_array_almost_equal(param1.get_value(), param2.get_value(), err_msg=param1.name)
 
-        # I tested it, they are exactly equal when using float64.
+        # Using `assert_array_*almost*_equal` because of float32. However, this is not needed in float64.
         assert_array_almost_equal(nll1.mean.view(trainer1.status), nll2b.mean.view(trainer2b.status))
         assert_array_almost_equal(nll1.stderror.view(trainer1.status), nll2b.stderror.view(trainer2b.status))
 
-        # I tested it, they are exactly equal when using float64 on CPU.
-        assert_array_almost_equal(logger1.get_variable_history(0), logger2a.get_variable_history(0)+logger2b.get_variable_history(0))
-        assert_array_almost_equal(logger1.get_variable_history(1), logger2a.get_variable_history(1)+logger2b.get_variable_history(1))
+        # Using `assert_array_*almost*_equal` because of float32. However, this is not needed in float64.
+        assert_array_almost_equal(logger1.get_variable_history(0), logger2b.get_variable_history(0))
+        assert_array_almost_equal(logger1.get_variable_history(1), logger2b.get_variable_history(1))
 
-        # Check that concatenating `logger2a` with `logger2b` is the same as `logger1`.
+        # Check that the _history of `logger2b` is the same as the one in `logger1`.
         for i in range(len(logger1[0])):
-            assert_equal(logger2a._history[i] + logger2b._history[i], logger1._history[i])
+            assert_equal(logger2b._history[i], logger1._history[i])


### PR DESCRIPTION
This PR adds the missing save function to the task `Logger`.

This PR also adds a new view `CallbackView` that allows computing some values/results during training and cache them (thanks to the `View` behaviour). E.g.

``` python
valid_bpc = views.CallbackView(lambda *args: model.compute_bpc(validset))
trainer.append_task(tasks.Print("valid bpc {:.4f}", valid_bpc))
logger = tasks.Logger(valid_bpc)  # Avoid recomputing bpc thanks to the cache
```

This PR also add a `__getitem__` to the view `ItemGetter`. This is useful when debugging/monitoring  the training process. For instance,

``` python
valid_loss_view = views.LossView(loss=valid_loss, batch_scheduler=valid_batch_scheduler)
# In the next line, valid_loss_view.values is a `ItemGetter` object.
trainer.append_task(tasks.Print("valid 30th NLL: {:.4f}", valid_loss_view.values[30]))
```
